### PR TITLE
Update HexagonalGridCalculatorImpl.java

### DIFF
--- a/src/main/java/biz/pavonis/hexameter/internal/impl/HexagonalGridCalculatorImpl.java
+++ b/src/main/java/biz/pavonis/hexameter/internal/impl/HexagonalGridCalculatorImpl.java
@@ -27,16 +27,19 @@ public final class HexagonalGridCalculatorImpl implements
         return (int) max(max(absX, absY), absZ);
     }
 
-    public Set<Hexagon> calculateMovementRangeFrom(Hexagon hexagon, int distance) {
-        Set<Hexagon> ret = new HashSet<Hexagon>();
-        for (int x = -distance; x <= distance; x++) {
-            for (int y = max(-distance, -x - distance); y <= min(distance, -x
-                    + distance); y++) {
-                int z = -x - y;
-                ret.add(hexagonalGrid.getByGridCoordinate(hexagon.getGridX()
-                        + x, hexagon.getGridZ() + z));
-            }
-        }
-        return ret;
-    }
+    	public Set<Hexagon> calculateMovementRangeFrom(Hexagon hexagon, int distance) {
+		Set<Hexagon> ret = new HashSet<Hexagon>();
+		for (int x = -distance; x <= distance; x++) {
+			for (int y = max(-distance, -x - distance); y <= min(distance, -x + distance); y++) {
+				int z = -x - y;
+				int tmpX = hexagon.getGridX() + x;
+				int tmpZ = hexagon.getGridZ() + z;
+				if (hexagonalGrid.containsCoordinate(tmpX, tmpZ)) {
+					Hexagon hex = hexagonalGrid.getByGridCoordinate(tmpX, tmpZ);
+					ret.add(hex);
+				}
+			}
+		}
+		return ret;
+	}
 }


### PR DESCRIPTION
Prevents exceptions like this:
```
biz.pavonis.hexameter.api.exception.HexagonNotFoundException: Coordinates are off the grid: (x=-1,z=2)
	at biz.pavonis.hexameter.internal.impl.HexagonalGridImpl.checkCoordinate(HexagonalGridImpl.java:101)
	at biz.pavonis.hexameter.internal.impl.HexagonalGridImpl.getByGridCoordinate(HexagonalGridImpl.java:95)
	at biz.pavonis.hexameter.internal.impl.HexagonalGridCalculatorImpl.calculateMovementRangeFrom(HexagonalGridCalculatorImpl.java:51)```