### PR TITLE
Fix compilation errors & use diamonds.

### DIFF
--- a/src/main/java/biz/pavonis/hexameter/api/HexagonalGridBuilder.java
+++ b/src/main/java/biz/pavonis/hexameter/api/HexagonalGridBuilder.java
@@ -28,13 +28,13 @@ public final class HexagonalGridBuilder {
 	private int gridHeight;
 	private double radius;
 	private Map<String, Hexagon> customStorage;
-	private List<AxialCoordinate> customCoordinates = new ArrayList<AxialCoordinate>();
+	private List<AxialCoordinate> customCoordinates = new ArrayList<> ();
 	private HexagonOrientation orientation = HexagonOrientation.POINTY_TOP;
 	private HexagonalGridLayout gridLayout = HexagonalGridLayout.RECTANGULAR;
 
 	/**
 	 * Mandatory parameter. Sets the number of {@link Hexagon}s in the horizontal direction.
-	 * 
+	 *
 	 * @param gridWidth
 	 * @return this {@link HexagonalGridBuilder}
 	 */
@@ -45,7 +45,7 @@ public final class HexagonalGridBuilder {
 
 	/**
 	 * Mandatory parameter. Sets the number of {@link Hexagon}s in the vertical direction.
-	 * 
+	 *
 	 * @param gridHeight
 	 * @return this {@link HexagonalGridBuilder}
 	 */
@@ -57,7 +57,7 @@ public final class HexagonalGridBuilder {
 	/**
 	 * Sets the {@link HexagonOrientation} used in the resulting {@link HexagonalGrid}.
 	 * If it is not set HexagonOrientation.POINTY will be used.
-	 * 
+	 *
 	 * @param orientation
 	 * @return this {@link HexagonalGridBuilder}
 	 */
@@ -68,7 +68,7 @@ public final class HexagonalGridBuilder {
 
 	/**
 	 * Sets the radius of the {@link Hexagon}s contained in the resulting {@link HexagonalGrid}.
-	 * 
+	 *
 	 * @param radius in pixels
 	 * @return this {@link HexagonalGridBuilder}
 	 */
@@ -80,7 +80,7 @@ public final class HexagonalGridBuilder {
 	/**
 	 * Sets the {@link HexagonalGridLayout} which will be used when creating the {@link HexagonalGrid}.
 	 * If it is not set <pre>RECTANGULAR</pre> will be assumed.
-	 * 
+	 *
 	 * @param gridLayout
 	 * @return this {@link HexagonalGridBuilder}.
 	 */
@@ -91,7 +91,7 @@ public final class HexagonalGridBuilder {
 
 	/**
 	 * Adds a custom coordinate to the {@link HexagonalGrid} which will be produced.
-	 * 
+	 *
 	 * @param axialCoordinate
 	 * @return this {@link HexagonalGridBuilder}.
 	 */
@@ -116,7 +116,7 @@ public final class HexagonalGridBuilder {
 	 * <li> {@link Map#keySet()}</li>
 	 * </ul>
 	 * Others are not necessary but highly recommended. Refer to the javadoc of {@link AbstractMap} if you need help.
-	 * 
+	 *
 	 * @param customStorage
 	 * @return this {@link HexagonalGridBuilder}.
 	 */
@@ -130,7 +130,7 @@ public final class HexagonalGridBuilder {
 	 * Throws {@link HexagonalGridCreationException} if not all mandatory parameters
 	 * are filled and/or they are not valid. In both cases you will be supplied with
 	 * a {@link HexagonalGridCreationException} detailing the cause of failure.
-	 * 
+	 *
 	 * @return {@link HexagonalGrid}
 	 */
 	public HexagonalGrid build() {
@@ -140,7 +140,7 @@ public final class HexagonalGridBuilder {
 
 	/**
 	 * Creates a {@link HexagonalGridCalculator} for your {@link HexagonalGrid}.
-	 * 
+	 *
 	 * @param hexagonalGrid
 	 * @return calculator
 	 */

--- a/src/main/java/biz/pavonis/hexameter/api/HexagonalGridCalculator.java
+++ b/src/main/java/biz/pavonis/hexameter/api/HexagonalGridCalculator.java
@@ -1,5 +1,6 @@
 package biz.pavonis.hexameter.api;
 
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -20,7 +21,7 @@ public interface HexagonalGridCalculator {
 
 	/**
 	 * Calculates the distance (in hexagons) between two {@link Hexagon} objects on the grid.
-	 * 
+	 *
 	 * @param hex0
 	 * @param hex1
 	 * @return distance
@@ -29,16 +30,16 @@ public interface HexagonalGridCalculator {
 
 	/**
 	 * Returns all {@link Hexagon}s which are within distance (inclusive) from the {@link Hexagon}.
-	 * 
+	 *
 	 * @param hexagon {@link Hexagon}
 	 * @param distance
 	 * @return {@link Hexagon}s within distance (inclusive)
 	 */
 	Set<Hexagon> calculateMovementRangeFrom(Hexagon hexagon, int distance);
-	
+
 	/**
 	 * Returns the shortest path between start and end {@link Hexagon}.
-	 * 
+	 *
 	 * @param start
 	 *            the path starts here.
 	 * @param end

--- a/src/main/java/biz/pavonis/hexameter/internal/impl/HexagonImpl.java
+++ b/src/main/java/biz/pavonis/hexameter/internal/impl/HexagonImpl.java
@@ -25,7 +25,7 @@ public class HexagonImpl implements Hexagon {
 
     public HexagonImpl(SharedHexagonData sharedHexagonData, int gridX, int gridZ) {
         this.sharedHexagonData = sharedHexagonData;
-        this.satelliteData = new AtomicReference<Object>();
+        this.satelliteData = new AtomicReference<> ();
         double height = sharedHexagonData.getHeight();
         double width = sharedHexagonData.getWidth();
         double radius = sharedHexagonData.getRadius();

--- a/src/main/java/biz/pavonis/hexameter/internal/impl/HexagonalGridCalculatorImpl.java
+++ b/src/main/java/biz/pavonis/hexameter/internal/impl/HexagonalGridCalculatorImpl.java
@@ -4,12 +4,21 @@ import static java.lang.Math.abs;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Queue;
 import java.util.Set;
 
 import biz.pavonis.hexameter.api.Hexagon;
 import biz.pavonis.hexameter.api.HexagonalGrid;
 import biz.pavonis.hexameter.api.HexagonalGridCalculator;
+import biz.pavonis.hexameter.api.PathfindingAlgorithm;
 
 public final class HexagonalGridCalculatorImpl implements
         HexagonalGridCalculator {
@@ -28,7 +37,7 @@ public final class HexagonalGridCalculatorImpl implements
     }
 
     	public Set<Hexagon> calculateMovementRangeFrom(Hexagon hexagon, int distance) {
-		Set<Hexagon> ret = new HashSet<Hexagon>();
+		Set<Hexagon> ret = new HashSet<> ();
 		for (int x = -distance; x <= distance; x++) {
 			for (int y = max(-distance, -x - distance); y <= min(distance, -x + distance); y++) {
 				int z = -x - y;
@@ -42,8 +51,9 @@ public final class HexagonalGridCalculatorImpl implements
 		}
 		return ret;
 	}
-	
-	private class HexIntComparator implements Comparator<Hexagon> {
+
+	private class HexIntComparator implements Comparator<Hexagon>
+  {
 		@Override
 		public int compare(Hexagon o1, Hexagon o2) {
 			Integer prio1 = (Integer) o1.getSatelliteData();
@@ -70,7 +80,7 @@ public final class HexagonalGridCalculatorImpl implements
 		}
 
 		Hexagon current = end;
-		List<Hexagon> path = new LinkedList<Hexagon>();
+		List<Hexagon> path = new LinkedList<> ();
 		path.add(current);
 		while (!current.equals(start)) {
 			current = cameFrom.get(current);
@@ -81,12 +91,12 @@ public final class HexagonalGridCalculatorImpl implements
 	}
 
 	private Map<Hexagon, Hexagon> aStar(Hexagon start, Hexagon end) {
-		PriorityQueue<Hexagon> frontier = new PriorityQueue<Hexagon>(new HexIntComparator());
-		start.setSatelliteData(new Integer(0));
+		PriorityQueue<Hexagon> frontier = new PriorityQueue<> (11, new HexIntComparator ());
+		start.setSatelliteData(0);
 		frontier.add(start);
-		Map<Hexagon, Hexagon> cameFrom = new HashMap<Hexagon, Hexagon>();
+		Map<Hexagon, Hexagon> cameFrom = new HashMap<> ();
 		cameFrom.put(start, null);
-		Map<Hexagon, Integer> costSoFar = new HashMap<Hexagon, Integer>();
+		Map<Hexagon, Integer> costSoFar = new HashMap<> ();
 		costSoFar.put(start, 0);
 
 		while (!frontier.isEmpty()) {
@@ -100,7 +110,7 @@ public final class HexagonalGridCalculatorImpl implements
 				if ((!costSoFar.containsKey(next)) || newCost < costSoFar.get(next)) {
 					costSoFar.put(next, newCost);
 					int prio = calculateDistanceBetween(end, next);
-					next.setSatelliteData(new Integer(prio));
+					next.setSatelliteData(prio);
 					frontier.add(next);
 					cameFrom.put(next, current);
 				}
@@ -110,9 +120,9 @@ public final class HexagonalGridCalculatorImpl implements
 	}
 
 	private Map<Hexagon, Hexagon> breadthFirst(Hexagon start, Hexagon end) {
-		Queue<Hexagon> frontier = new LinkedList<Hexagon>();
+		Queue<Hexagon> frontier = new LinkedList<> ();
 		frontier.add(start);
-		Map<Hexagon, Hexagon> cameFrom = new HashMap<Hexagon, Hexagon>();
+		Map<Hexagon, Hexagon> cameFrom = new HashMap<> ();
 		cameFrom.put(start, null);
 
 		while (!frontier.isEmpty()) {
@@ -132,10 +142,10 @@ public final class HexagonalGridCalculatorImpl implements
 	}
 
 	private Map<Hexagon, Hexagon> greedyBestFirst(Hexagon start, Hexagon end) {
-		PriorityQueue<Hexagon> frontier = new PriorityQueue<Hexagon>(new HexIntComparator());
-		start.setSatelliteData(new Integer(0));
+		PriorityQueue<Hexagon> frontier = new PriorityQueue<> (11, new HexIntComparator ());
+		start.setSatelliteData(0);
 		frontier.add(start);
-		Map<Hexagon, Hexagon> cameFrom = new HashMap<Hexagon, Hexagon>();
+		Map<Hexagon, Hexagon> cameFrom = new HashMap<> ();
 		cameFrom.put(start, null);
 
 		while (!frontier.isEmpty()) {
@@ -147,7 +157,7 @@ public final class HexagonalGridCalculatorImpl implements
 			for (Hexagon next : neigbours) {
 				if (!cameFrom.containsKey(next)) {
 					int prio = calculateDistanceBetween(end, next);
-					next.setSatelliteData(new Integer(prio));
+					next.setSatelliteData(prio);
 					frontier.add(next);
 					cameFrom.put(next, current);
 				}

--- a/src/main/java/biz/pavonis/hexameter/internal/impl/HexagonalGridImpl.java
+++ b/src/main/java/biz/pavonis/hexameter/internal/impl/HexagonalGridImpl.java
@@ -35,7 +35,7 @@ public final class HexagonalGridImpl implements HexagonalGrid {
         if (builder.getCustomStorage() != null) {
             hexagonStorage = builder.getCustomStorage();
         } else {
-            hexagonStorage = new ConcurrentHashMap<String, Hexagon>(); // TODO:
+            hexagonStorage = new ConcurrentHashMap<> (); // TODO:
                                                                        // to
                                                                        // factory
                                                                        // method
@@ -49,7 +49,7 @@ public final class HexagonalGridImpl implements HexagonalGrid {
 
     public Map<String, Hexagon> getHexagonsByAxialRange(int gridXFrom,
             int gridXTo, int gridZFrom, int gridZTo) {
-        Map<String, Hexagon> range = new HashMap<String, Hexagon>();
+        Map<String, Hexagon> range = new HashMap<> ();
         for (int gridZ = gridZFrom; gridZ <= gridZTo; gridZ++) {
             for (int gridX = gridXFrom; gridX <= gridXTo; gridX++) {
                 String key = createKeyFromCoordinate(gridX, gridZ);
@@ -61,7 +61,7 @@ public final class HexagonalGridImpl implements HexagonalGrid {
 
     public Map<String, Hexagon> getHexagonsByOffsetRange(int gridXFrom,
             int gridXTo, int gridYFrom, int gridYTo) {
-        Map<String, Hexagon> range = new HashMap<String, Hexagon>();
+        Map<String, Hexagon> range = new HashMap<> ();
         for (int gridY = gridYFrom; gridY <= gridYTo; gridY++) {
             for (int gridX = gridXFrom; gridX <= gridXTo; gridX++) {
                 int axialX = convertOffsetCoordinatesToAxialX(gridX, gridY,
@@ -124,7 +124,7 @@ public final class HexagonalGridImpl implements HexagonalGrid {
     }
 
     public Set<Hexagon> getNeighborsOf(Hexagon hexagon) {
-        Set<Hexagon> neighbors = new HashSet<Hexagon>();
+        Set<Hexagon> neighbors = new HashSet<> ();
         for (int[] neighbor : NEIGHBORS) {
             Hexagon retHex = null;
             int neighborGridX = hexagon.getGridX() + neighbor[NEIGHBOR_X_INDEX];

--- a/src/main/java/biz/pavonis/hexameter/internal/impl/layoutstrategy/CustomGridLayoutStrategy.java
+++ b/src/main/java/biz/pavonis/hexameter/internal/impl/layoutstrategy/CustomGridLayoutStrategy.java
@@ -14,7 +14,7 @@ import biz.pavonis.hexameter.api.HexagonalGridBuilder;
 public final class CustomGridLayoutStrategy extends AbstractGridLayoutStrategy {
 
 	public Map<String, Hexagon> createHexagons(HexagonalGridBuilder builder) {
-		Map<String, Hexagon> hexagons = new HashMap<String, Hexagon>();
+		Map<String, Hexagon> hexagons = new HashMap<> ();
 		addCustomHexagons(builder, hexagons);
 		return hexagons;
 	}

--- a/src/main/java/biz/pavonis/hexameter/internal/impl/layoutstrategy/HexagonalGridLayoutStrategy.java
+++ b/src/main/java/biz/pavonis/hexameter/internal/impl/layoutstrategy/HexagonalGridLayoutStrategy.java
@@ -1,10 +1,11 @@
 package biz.pavonis.hexameter.internal.impl.layoutstrategy;
 
-import static biz.pavonis.hexameter.api.CoordinateConverter.createKeyFromCoordinate;
 import static java.lang.Math.abs;
 import static java.lang.Math.floor;
 import static java.lang.Math.max;
 import static java.lang.Math.round;
+
+import static biz.pavonis.hexameter.api.CoordinateConverter.createKeyFromCoordinate;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -23,7 +24,7 @@ public final class HexagonalGridLayoutStrategy extends AbstractGridLayoutStrateg
 
 	public Map<String, Hexagon> createHexagons(HexagonalGridBuilder builder) {
 		double gridSize = builder.getGridHeight();
-		Map<String, Hexagon> hexagons = new HashMap<String, Hexagon>();
+		Map<String, Hexagon> hexagons = new HashMap<> ();
 		int startX = HexagonOrientation.FLAT_TOP.equals(builder.getOrientation()) ? (int) floor(gridSize / 2d) : (int) round(gridSize / 4d);
 		int hexRadius = (int) floor(gridSize / 2d);
 		int minX = startX - hexRadius;

--- a/src/main/java/biz/pavonis/hexameter/internal/impl/layoutstrategy/RectangularGridLayoutStrategy.java
+++ b/src/main/java/biz/pavonis/hexameter/internal/impl/layoutstrategy/RectangularGridLayoutStrategy.java
@@ -19,7 +19,7 @@ import biz.pavonis.hexameter.internal.impl.HexagonImpl;
 public final class RectangularGridLayoutStrategy extends AbstractGridLayoutStrategy {
 
 	public Map<String, Hexagon> createHexagons(HexagonalGridBuilder builder) {
-		Map<String, Hexagon> hexagons = new HashMap<String, Hexagon>();
+		Map<String, Hexagon> hexagons = new HashMap<> ();
 		for (int y = 0; y < builder.getGridHeight(); y++) {
 			for (int x = 0; x < builder.getGridWidth(); x++) {
 				int gridX = convertOffsetCoordinatesToAxialX(x, y, builder.getOrientation());

--- a/src/main/java/biz/pavonis/hexameter/internal/impl/layoutstrategy/TrapezoidGridLayoutStrategy.java
+++ b/src/main/java/biz/pavonis/hexameter/internal/impl/layoutstrategy/TrapezoidGridLayoutStrategy.java
@@ -12,7 +12,7 @@ import biz.pavonis.hexameter.internal.impl.HexagonImpl;
 public final class TrapezoidGridLayoutStrategy extends AbstractGridLayoutStrategy {
 
 	public Map<String, Hexagon> createHexagons(HexagonalGridBuilder builder) {
-		Map<String, Hexagon> hexagons = new HashMap<String, Hexagon>();
+		Map<String, Hexagon> hexagons = new HashMap<>();
 		for (int y = 0; y < builder.getGridHeight(); y++) {
 			for (int x = 0; x < builder.getGridWidth(); x++) {
 				Hexagon hexagon = new HexagonImpl(builder.getSharedHexagonData(), x, y);

--- a/src/main/java/biz/pavonis/hexameter/internal/impl/layoutstrategy/TriangularGridLayoutStrategy.java
+++ b/src/main/java/biz/pavonis/hexameter/internal/impl/layoutstrategy/TriangularGridLayoutStrategy.java
@@ -18,7 +18,7 @@ public final class TriangularGridLayoutStrategy extends AbstractGridLayoutStrate
 
 	public Map<String, Hexagon> createHexagons(HexagonalGridBuilder builder) {
 		int gridSize = builder.getGridHeight();
-		Map<String, Hexagon> hexagons = new HashMap<String, Hexagon>();
+		Map<String, Hexagon> hexagons = new HashMap<> ();
 		for (int y = 0; y < gridSize; y++) {
 			int endX = gridSize - y;
 			for (int x = 0; x < endX; x++) {

--- a/src/test/java/biz/pavonis/hexameter/api/HexagonalGridBuilderTest.java
+++ b/src/test/java/biz/pavonis/hexameter/api/HexagonalGridBuilderTest.java
@@ -92,7 +92,7 @@ public class HexagonalGridBuilderTest {
 
 	@Test
 	public void testSetCustomStorage() {
-		Map<String, Hexagon> customStorage = new HashMap<String, Hexagon>();
+		Map<String, Hexagon> customStorage = new HashMap<> ();
 		target.setCustomStorage(customStorage);
 		assertEquals(customStorage, target.getCustomStorage());
 	}

--- a/src/test/java/biz/pavonis/hexameter/internal/impl/HexagonalGridCalculatorImplTest.java
+++ b/src/test/java/biz/pavonis/hexameter/internal/impl/HexagonalGridCalculatorImplTest.java
@@ -36,7 +36,7 @@ public class HexagonalGridCalculatorImplTest {
     @Test
     public void testCalculateMovementRangeFromWithDistanceOf1() {
         Hexagon hex = grid.getByGridCoordinate(3, 7);
-        Set<Hexagon> expected = new HashSet<Hexagon>();
+        Set<Hexagon> expected = new HashSet<> ();
         expected.add(hex);
         expected.add(grid.getByGridCoordinate(3, 6));
         expected.add(grid.getByGridCoordinate(4, 6));
@@ -51,7 +51,7 @@ public class HexagonalGridCalculatorImplTest {
     @Test
     public void testCalculateMovementRangeFromWithDistanceOf2() {
         Hexagon hex = grid.getByGridCoordinate(3, 7);
-        Set<Hexagon> expected = new HashSet<Hexagon>();
+        Set<Hexagon> expected = new HashSet<> ();
         expected.add(hex);
         expected.add(grid.getByGridCoordinate(3, 6));
         expected.add(grid.getByGridCoordinate(4, 6));

--- a/src/test/java/biz/pavonis/hexameter/internal/impl/HexagonalGridImplTest.java
+++ b/src/test/java/biz/pavonis/hexameter/internal/impl/HexagonalGridImplTest.java
@@ -41,7 +41,7 @@ public class HexagonalGridImplTest {
 
 	@Test
 	public void testHexagonalGridImplWithCustomStorage() {
-		Map<String, Hexagon> expected = new HashMap<String, Hexagon>();
+		Map<String, Hexagon> expected = new HashMap<> ();
 		builder.setCustomStorage(expected);
 		target = builder.build();
 		assertEquals(expected, target.getHexagons());
@@ -66,7 +66,7 @@ public class HexagonalGridImplTest {
 
 	@Test
 	public void testGetHexagonsByAxialRange() {
-		Set<Hexagon> expected = new HashSet<Hexagon>();
+		Set<Hexagon> expected = new HashSet<> ();
 
 		expected.add(target.getByGridCoordinate(2, 3));
 		expected.add(target.getByGridCoordinate(3, 3));
@@ -91,7 +91,7 @@ public class HexagonalGridImplTest {
 
 	@Test
 	public void testGetHexagonsByOffsetRange() {
-		Set<Hexagon> expected = new HashSet<Hexagon>();
+		Set<Hexagon> expected = new HashSet<> ();
 
 		expected.add(target.getByGridCoordinate(1, 3));
 		expected.add(target.getByGridCoordinate(2, 3));
@@ -184,7 +184,7 @@ public class HexagonalGridImplTest {
 	@Test
 	public void testGetNeighborsOfFromMiddle() {
 		Hexagon hex = target.getByGridCoordinate(3, 7);
-		Set<Hexagon> expected = new HashSet<Hexagon>();
+		Set<Hexagon> expected = new HashSet<> ();
 		expected.add(target.getByGridCoordinate(3, 6));
 		expected.add(target.getByGridCoordinate(4, 6));
 		expected.add(target.getByGridCoordinate(4, 7));
@@ -198,7 +198,7 @@ public class HexagonalGridImplTest {
 	@Test
 	public void testGetNeighborsOfFromEdge() {
 		Hexagon hex = target.getByGridCoordinate(5, 9);
-		Set<Hexagon> expected = new HashSet<Hexagon>();
+		Set<Hexagon> expected = new HashSet<> ();
 		expected.add(target.getByGridCoordinate(5, 8));
 		expected.add(target.getByGridCoordinate(4, 9));
 		Set<Hexagon> actual = target.getNeighborsOf(hex);

--- a/src/test/java/biz/pavonis/hexameter/internal/impl/layoutstrategy/AbstractGridLayoutStrategyTest.java
+++ b/src/test/java/biz/pavonis/hexameter/internal/impl/layoutstrategy/AbstractGridLayoutStrategyTest.java
@@ -27,7 +27,7 @@ public class AbstractGridLayoutStrategyTest {
 		target = new AbstractGridLayoutStrategy() {
 
 			public Map<String, Hexagon> createHexagons(HexagonalGridBuilder builder) {
-				return new HashMap<String, Hexagon>();
+				return new HashMap<> ();
 			}
 		};
 	}


### PR DESCRIPTION
- Fix missing imports causing compilation failure.

- Add initial capacity to PriorityQueue constructors, as a
  Comparator-only constructor does not exist for this class until Java 8
  (but maven-compiler-plugin in pom.xml specifies 1.7). Use 11 as initial
  capacity because this is default in Oracle JDK 1.7.

- Use Java 7 diamond operator.

- Remove unnecessary Integer boxing's.

- Fix minor javadoc formatting issues.